### PR TITLE
Ros source lockdown

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,5 @@
 FROM ubuntu:xenial
 
-# Enable multiverse as snapcraft cleanbuild does.
-RUN sed -i 's/ universe/ universe multiverse/' /etc/apt/sources.list
-
 RUN apt-get update && \
   apt-get dist-upgrade --yes && \
   apt-get autoclean --yes && \
@@ -17,10 +14,10 @@ RUN apt-get install git sudo libslang2-dev python-pip python3-pip gcc g++ make p
 ADD ./ /snapcraft
 
 RUN mkdir -p /venv/snapcraft && \
-python3 -m venv /venv/snapcraft && \
-. /venv/snapcraft/bin/activate && \
-pip --no-cache-dir install wheel && \
-pip --no-cache-dir install -r /snapcraft/requirements.txt
+  python3 -m venv /venv/snapcraft && \
+  . /venv/snapcraft/bin/activate && \
+  pip --no-cache-dir install wheel && \
+  pip --no-cache-dir install -r /snapcraft/requirements.txt
 
 
 ADD docker-files/snapcraft /bin/snapcraft

--- a/snapcraft/plugins/_python/_pip.py
+++ b/snapcraft/plugins/_python/_pip.py
@@ -237,8 +237,16 @@ class Pip:
         # --disable-pip-version-check: Don't whine if pip is out-of-date with
         #                              the version on pypi.
         # --dest: Download packages into the directory we've set aside for it.
-        self._run(['download', '--disable-pip-version-check', '--dest',
-                   self._python_package_dir] + args, cwd=cwd)
+        pip_cmd = ['download', '--disable-pip-version-check', '--dest',
+                   self._python_package_dir]
+
+        # --index url for installation from a local mirror.
+        if os.environ.get("LOCAL_PIP") is not None:
+            pip_index = os.environ.get("LOCAL_PIP")
+            pip_host = pip_index.split('/')[2].split(':')[0]
+            pip_cmd.extend(['--index-url', pip_index, '--trusted-host',
+                            pip_host])
+        self._run(pip_cmd + args, cwd=cwd)
 
     def install(self, packages, *, setup_py_dir=None, constraints=None,
                 requirements=None, process_dependency_links=False,

--- a/snapcraft/plugins/_ros/rosdep.py
+++ b/snapcraft/plugins/_ros/rosdep.py
@@ -18,6 +18,7 @@ import os
 import logging
 import re
 import shutil
+import snapcraft
 import subprocess
 import sys
 
@@ -48,10 +49,12 @@ class RosdepUnexpectedResultError(errors.SnapcraftError):
 
 class Rosdep:
     def __init__(self, *, ros_distro, ros_package_path, rosdep_path,
-                 ubuntu_distro, ubuntu_sources, project):
+                 rosdep_source, ubuntu_distro, ubuntu_sources,
+                 project):
         self._ros_distro = ros_distro
         self._ros_package_path = ros_package_path
         self._rosdep_path = rosdep_path
+        self._rosdep_source = rosdep_source
         self._ubuntu_distro = ubuntu_distro
         self._ubuntu_sources = ubuntu_sources
         self._project = project
@@ -83,13 +86,17 @@ class Rosdep:
         logger.info('Installing rosdep...')
         ubuntu.unpack(self._rosdep_install_path)
 
-        logger.info('Initializing rosdep database...')
-        try:
-            self._run(['init'])
-        except subprocess.CalledProcessError as e:
-            output = e.output.decode(sys.getfilesystemencoding()).strip()
-            raise RuntimeError(
-                'Error initializing rosdep database:\n{}'.format(output))
+        if self._rosdep_source is None:
+            logger.info('Initializing rosdep database...')
+            try:
+                self._run(['init'])
+            except subprocess.CalledProcessError as e:
+                output = e.output.decode(sys.getfilesystemencoding()).strip()
+                raise RuntimeError(
+                    'Error initializing rosdep database:\n{}'.format(output))
+        else:
+            snapcraft.file_utils.link_or_copy_tree(
+                self._rosdep_source, self._rosdep_sources_path)
 
         logger.info('Updating rosdep database...')
         try:

--- a/snapcraft/plugins/catkin.py
+++ b/snapcraft/plugins/catkin.py
@@ -132,6 +132,9 @@ class CatkinPlugin(snapcraft.BasePlugin):
             'type': 'string',
             'default': 'indigo'
         }
+        schema['properties']['rosdep-sources'] = {
+            'type': 'string',
+        }
         schema['properties']['catkin-packages'] = {
             'type': 'array',
             'minitems': 1,
@@ -430,6 +433,7 @@ class CatkinPlugin(snapcraft.BasePlugin):
         rosdep = _ros.rosdep.Rosdep(
             ros_distro=self.options.rosdistro,
             ros_package_path=self._ros_package_path,
+            rosdep_source=self.options.rosdep_sources,
             rosdep_path=self._rosdep_path,
             ubuntu_distro=_ROS_RELEASE_MAP[self.options.rosdistro],
             ubuntu_sources=self.PLUGIN_STAGE_SOURCES,


### PR DESCRIPTION
Locking down sources related to ros.  

Pip can use a local repository
rosdep can be sourced from a local file.
multiverse is no longer able to pull in packages.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/badgertechnologies/snapcraft/2)
<!-- Reviewable:end -->
