### PR TITLE
Snapcraft improvements

### DIFF
--- a/snapcraft/internal/pluginhandler/__init__.py
+++ b/snapcraft/internal/pluginhandler/__init__.py
@@ -22,6 +22,7 @@ import os
 import shutil
 import sys
 from glob import glob, iglob
+from multiprocessing import Pool
 
 import yaml
 
@@ -443,8 +444,12 @@ class PluginHandler:
 
         elf_files = elf.get_elf_files(self.primedir, snap_files)
         dependencies = set()
-        for elf_file in elf_files:
-            dependencies.update(elf.get_dependencies(elf_file.path))
+
+        elf_dependencies = Pool().map(elf.get_dependencies,
+                              [elf_file.path for elf_file in elf_files])
+
+        if len(elf_dependencies) > 0:
+            dependencies.update(set.union(*elf_dependencies))
 
         # Split the necessary dependencies into their corresponding location.
         # We'll both migrate and track the system dependencies, but we'll only

--- a/snapcraft/plugins/catkin_tools.py
+++ b/snapcraft/plugins/catkin_tools.py
@@ -119,6 +119,9 @@ class CatkinToolsPlugin(snapcraft.plugins.catkin.CatkinPlugin):
         # Prevent notification that the build is complete.
         catkincmd.append('--no-notify')
 
+        # Limit status refresh rate
+        catkincmd.extend([' --limit-status-rate', '1'])
+
         # Use the newly created default profile.
         catkincmd.extend(['--profile', 'default'])
 


### PR DESCRIPTION
Identified some slow running portions in the Prime step of building snapcraft.  The Prime set was going through and looking at each file to identify if it is an ELF file, then running ldd on all ELF files.  I set this to run in a pool so it can be parallelized.  This cuts about 4 minutes from bar_truck build time.

Also rate limited the catkin status output since this was requested.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/badgertechnologies/snapcraft/3)
<!-- Reviewable:end -->
